### PR TITLE
Engine: add Anchor regex support

### DIFF
--- a/Engine/BooleanSemantics.v
+++ b/Engine/BooleanSemantics.v
@@ -291,8 +291,10 @@ Proof.
     { inversion H1. inversion H0. subst. repeat progress (constructor; auto). }
     apply encode_next in ENCODE.
     apply encode_next. apply encode_close. auto.
+  - apply encode_next in ENCODE.
+    econstructor; eauto.
 Qed.
-    
+
 Corollary boolean_correct:
   forall r inp t,
     pike_regex r ->

--- a/Engine/Complexity.v
+++ b/Engine/Complexity.v
@@ -442,7 +442,6 @@ Fixpoint compsize (r:regex) : nat :=
   | Sequence r1 r2 => compsize r1 + compsize r2
   | Quantified g 0 (NoI.Inf) r1 => 4 + compsize r1
   | Group _ r1 => 2 + compsize r1
-  (* FIXME(mw): why without this all proofs pass anyway? *)
   | Anchor _ => 1
   | _ => 0
   end.

--- a/Engine/Complexity.v
+++ b/Engine/Complexity.v
@@ -260,6 +260,9 @@ Proof.
     (* in r1 *)
     apply IHREP in IN; auto.
   - assert (pc = lbl) by lia. subst.
+    rewrite CHECK in GET. inversion GET. subst.
+    simpl in IN. destruct IN; lia.
+  - assert (pc = lbl) by lia. subst.
     rewrite KILL in GET. inversion GET. subst.
     simpl in IN. inversion IN.
 Qed.
@@ -288,7 +291,7 @@ Proof.
   specialize (nfa_wf r c 0 (length c) pc next i REP POS H1 GETI IN) as WF.
   unfold size. rewrite app_length. simpl. lia.
 Qed.
-  
+
 Lemma eps_step_blocked_wf:
   forall t code inp newt,
     epsilon_step rer t code inp = EpsBlocked newt ->
@@ -300,6 +303,7 @@ Proof.
   destruct b0; inversion H; subst.
   - destruct (check_read rer c inp forward); inversion H1; subst.
     simpl; eexists; split; eauto; simpl; auto; lia.
+  - destruct (anchor_satisfied rer a inp); inversion H1; subst.
   - destruct b; inversion H1.
 Qed.
 
@@ -317,6 +321,9 @@ Proof.
     try solve[inversion IN; subst; try solve [inversion H0];
               simpl; eexists; split; eauto; simpl; auto; lia].
   - destruct (check_read rer c inp forward); inversion H1; subst;
+      inversion IN; subst; try solve [inversion H0];
+      simpl; eexists; split; eauto; simpl; auto; lia.
+  - destruct (anchor_satisfied rer a inp); inversion H1; subst;
       inversion IN; subst; try solve [inversion H0];
       simpl; eexists; split; eauto; simpl; auto; lia.
   - inversion IN; [|inversion H0]; subst; try solve [inversion H1];
@@ -340,6 +347,7 @@ Proof.
   2: { inversion H. simpl. lia. }
   destruct b0; try solve [inversion H; simpl; lia].
   - destruct (check_read rer c inp forward); try solve [inversion H; simpl; lia].
+  - destruct (anchor_satisfied rer a inp); try solve [inversion H; simpl; lia].
   - destruct b; try solve [inversion H; simpl; lia].
 Qed.
 
@@ -434,6 +442,8 @@ Fixpoint compsize (r:regex) : nat :=
   | Sequence r1 r2 => compsize r1 + compsize r2
   | Quantified g 0 (NoI.Inf) r1 => 4 + compsize r1
   | Group _ r1 => 2 + compsize r1
+  (* FIXME(mw): why without this all proofs pass anyway? *)
+  | Anchor _ => 1
   | _ => 0
   end.
 

--- a/Engine/NFA.v
+++ b/Engine/NFA.v
@@ -14,6 +14,7 @@ Definition label : Type := nat.
 Inductive bytecode: Type :=
 | Accept
 | Consume: char_descr -> bytecode
+| CheckAnchor: anchor -> bytecode
 | Jmp: label -> bytecode
 | Fork: label -> label -> bytecode
 | SetRegOpen: group_id -> bytecode
@@ -92,7 +93,7 @@ Qed.
 
 Definition next_pcs (pc:label) (b:bytecode) : list label :=
   match b with
-  | Consume _ | SetRegOpen _ | SetRegClose _ | ResetRegs _ | BeginLoop => [S pc]
+  | Consume _ | CheckAnchor _ | SetRegOpen _ | SetRegClose _ | ResetRegs _ | BeginLoop => [S pc]
   | Accept | KillThread => []
   | Jmp l | EndLoop l => [l]
   | Fork l1 l2 => [l1; l2]
@@ -124,6 +125,7 @@ Fixpoint compile (r:regex) (fresh:label) : code * label :=
   | Group gid r1 =>
       let (bc1, f1) := compile r1 (S fresh) in
       ([SetRegOpen gid] ++ bc1 ++ [SetRegClose gid], S f1)
+  | Anchor a => ([CheckAnchor a], S fresh)
   | _ => ([KillThread], S fresh) (* unsupported features *)
   end.
 
@@ -172,6 +174,10 @@ Inductive nfa_rep : regex -> code -> label -> label -> Prop :=
     (NFA1: nfa_rep r1 c (S start) end1)
     (CLOSE: get_pc c end1 = Some (SetRegClose gid)),
     nfa_rep (Group gid r1) c start (S end1)
+| nfa_rep_anchor:
+  forall c a lbl
+    (CHECK: get_pc c lbl = Some (CheckAnchor a)),
+    nfa_rep (Anchor a) c lbl (S lbl)
 | nfa_unsupported:
   forall c r lbl
     (UNSUPPORTED: ~ pike_regex r)
@@ -300,9 +306,7 @@ Proof.
     + replace (prev ++ SetRegOpen id :: bc1 ++ [SetRegClose id]) with ((prev ++ SetRegOpen id :: bc1) ++ [SetRegClose id]).
       2:{ rewrite <- app_assoc. auto. }
       apply get_first_0. apply fresh_correct in COMP1. subst. rewrite app_length. simpl. lia.
-  - inversion H. subst. apply nfa_unsupported.
-    + unfold not. intros. inversion H0.
-    + rewrite get_first. simpl. auto.
+  - inversion H. subst. constructor. apply get_first.
   - inversion H. subst. apply nfa_unsupported.
     + unfold not. intros. inversion H0.
     + rewrite get_first. simpl. auto.

--- a/Engine/NFA.v
+++ b/Engine/NFA.v
@@ -426,5 +426,6 @@ Ltac invert_rep :=
    | [ H : nfa_rep (Sequence _ _) _ _ _ |- _ ] => inversion H; clear H; subst; try no_stutter
    | [ H : nfa_rep (Quantified _ _ _ _) _ _ _ |- _ ] => inversion H; clear H; subst; try no_stutter
    | [ H : nfa_rep (Group _ _) _ _ _ |- _ ] => inversion H; clear H; subst; try no_stutter
+   | [ H : nfa_rep (Anchor _) _ _ _ |- _ ] => inversion H; clear H; subst; try no_stutter
    | _ => try no_stutter
    end.

--- a/Engine/PikeEquiv.v
+++ b/Engine/PikeEquiv.v
@@ -1,3 +1,4 @@
+(* FIXME(mw): add anchor support *)
 (* Relating the PikeVM smallstep semantics to the Pike Tree smallstep semantics *)
 
 Require Import List Lia.
@@ -508,6 +509,7 @@ Qed.
 Inductive start_rep: bytecode -> Prop :=
 | start_accept: start_rep Accept
 | start_cons: forall cd, start_rep (Consume cd)
+| start_chkanch: forall a, start_rep (CheckAnchor a)
 | start_jmp: forall lbl, start_rep (Jmp lbl)
 | start_fork: forall l1 l2, start_rep (Fork l1 l2)
 | start_open: forall gid, start_rep (SetRegOpen gid)
@@ -747,6 +749,8 @@ Proof.
     { subst. rewrite CLOSE in GET. inversion GET. }
     (* in r1 *)
     apply IHREP; auto.
+  - assert (pc = lbl) by lia. subst.
+    rewrite CHECK in GET. inversion GET.
   - assert (pc = lbl) by lia. subst.
     rewrite KILL in GET. inversion GET.
 Qed.

--- a/Engine/PikeSubset.v
+++ b/Engine/PikeSubset.v
@@ -35,7 +35,10 @@ Inductive pike_regex : regex -> Prop :=
 | pike_group:
   forall g r1,
     pike_regex r1 ->
-    pike_regex (Group g r1).
+    pike_regex (Group g r1)
+| pike_anchor:
+  forall a, pike_regex (Anchor a).
+
 
 (* lifting to actions *)
 Inductive pike_action: action -> Prop :=
@@ -67,6 +70,9 @@ Inductive pike_subtree: tree -> Prop :=
 | pike_progress: forall t1,
     pike_subtree t1 ->
     pike_subtree (Progress t1)
+| pike_anchorpass: forall a t1,
+    pike_subtree t1 ->
+    pike_subtree (AnchorPass a t1)
 | pike_groupaction: forall ga t1,
     pike_subtree t1 ->
     pike_subtree (GroupAction ga t1).
@@ -173,6 +179,7 @@ Ltac in_subset :=
   | [ H : ~ pike_regex (Sequence _ _) |- _ ] => try solve[exfalso; apply H; pike_subset]
   | [ H : ~ pike_regex (Quantified _ _ _ _) |- _ ] => try solve[exfalso; apply H; pike_subset]
   | [ H : ~ pike_regex (Group _ _) |- _ ] => try solve[exfalso; apply H; pike_subset]
+  | [ H : ~ pike_regex (Anchor _) |- _ ] => try solve[exfalso; apply H; pike_subset]
   end.
 
 (* prove that one can only construct pike subtrees from pike regexes *)

--- a/Engine/PikeTree.v
+++ b/Engine/PikeTree.v
@@ -84,11 +84,12 @@ Definition StepDead := StepActive []. (* the thread died *)
 (* this corresponds to an atomic step of a single tree *)
 Definition tree_bfs_step (t:tree) (gm:group_map) (idx:nat): step_result :=
   match t with
-  | Mismatch | ReadBackRef _ _ | AnchorPass _ _ | LK _ _ _ | LKFail _ _ => StepDead
+  | Mismatch | ReadBackRef _ _ | LK _ _ _ | LKFail _ _ => StepDead
   | Match => StepMatch
   | Choice t1 t2 => StepActive [(t1,gm); (t2,gm)]
   | Read c t1 => StepBlocked t1
   | Progress t1 => StepActive [(t1,gm)]
+  | AnchorPass a t1 => StepActive [(t1,gm)]
   | GroupAction a t1 => StepActive [(t1, GroupMap.update idx a gm)]
   end.
 (* trees for unsupported features also return StepDead *)
@@ -184,12 +185,16 @@ Inductive tree_nd: tree -> group_map -> input -> seentrees -> option leaf -> Pro
   forall t gm inp l seen
     (TR: tree_nd t gm inp seen l),
     tree_nd (Progress t) gm inp seen l
+| tr_anchorpass:
+  forall a t gm inp l seen
+    (TR: tree_nd t gm inp seen l),
+    tree_nd (AnchorPass a t) gm inp seen l
 | tr_groupaction:
   forall t act gm inp l seen
     (TR: tree_nd t (GroupMap.update (idx inp) act gm) inp seen l),
     tree_nd (GroupAction act t) gm inp seen l.
 (* To keep this relation as simple as possible, it does not compute
-the results of a tree which does not corespond to the regexes
+the results of a tree which does not correspond to the regexes
 supported by the engine. We could support them, but we won't need them
 and it would require adding a direction as argument *)
 
@@ -518,7 +523,22 @@ Proof.
       eapply list_add_seen_nd with (gm:=gm) in TLR; auto.
       econstructor; eauto.
   (* anchor pass *)
-  - simpl. constructor; pike_subset; auto.
+  - constructor; pike_subset; auto. intros res STATEND. inversion STATEND; subst.
+    inversion ACTIVE; subst.
+    apply SAMERES.
+    apply add_parent_tree in TR.
+    2: { simpl. lia. }
+    assert (PARENT: tree_nd (AnchorPass a t) gm inp seen l1).
+    { apply tr_anchorpass; auto. }
+    (* case analysis: did t contribute to the result? *)
+    destruct l1 as [leaf1|].
+    + econstructor; eauto. simpl.
+      eapply tlr_cons; eauto.
+      apply list_result_nd; auto.
+    (* when the tree did not contribute, adding it to seen does not change the results *)
+    + econstructor; eauto.
+      eapply list_add_seen_nd with (gm:=gm) in TLR; auto.
+      econstructor; eauto.
   (* group action *)
   - simpl. constructor; pike_subset; auto. intros res STATEND. inversion STATEND; subst.
     inversion ACTIVE; subst.

--- a/Engine/PikeVM.v
+++ b/Engine/PikeVM.v
@@ -137,6 +137,10 @@ Definition epsilon_step (t:thread) (c:code) (i:input): epsilon_result :=
                          | CannotRead => EpsDead
                          | CanRead => EpsBlocked (block_thread t)
                          end
+          | CheckAnchor a => match anchor_satisfied rer a i with
+                            | false => EpsDead
+                            | true => EpsActive [advance_thread t]
+                            end
           | Jmp next => EpsActive [upd_label t next]
           | Fork l1 l2 => EpsActive [upd_label t l1; upd_label t l2]
           | SetRegOpen gid => EpsActive [open_thread t gid (idx i)]
@@ -163,6 +167,7 @@ Inductive pike_vm_state : Type :=
 Definition pike_vm_initial_state (inp:input) : pike_vm_state :=
   PVS inp [(0,GroupMap.empty,CanExit)] None [] initial_seenpcs.
 
+(* FIXME(mw): add anchor support *)
 (* small-step semantics for the PikeVM algorithm *)
 Inductive pike_vm_step (c:code): pike_vm_state -> pike_vm_state -> Prop :=
 | pvs_final:

--- a/Engine/PikeVM.v
+++ b/Engine/PikeVM.v
@@ -30,7 +30,7 @@ Module Type VMSeen.
 
 End VMSeen.
 
-(* one instanciation using lists, but you could use anything else *)
+(* one instantiation using lists, but you could use anything else *)
 Module VMS <: VMSeen.
   Definition seenpcs: Type := list (label * LoopBool).
   Definition initial_seenpcs : seenpcs := [].
@@ -167,7 +167,6 @@ Inductive pike_vm_state : Type :=
 Definition pike_vm_initial_state (inp:input) : pike_vm_state :=
   PVS inp [(0,GroupMap.empty,CanExit)] None [] initial_seenpcs.
 
-(* FIXME(mw): add anchor support *)
 (* small-step semantics for the PikeVM algorithm *)
 Inductive pike_vm_step (c:code): pike_vm_state -> pike_vm_state -> Prop :=
 | pvs_final:

--- a/Engine/TreeRep.v
+++ b/Engine/TreeRep.v
@@ -62,6 +62,17 @@ Inductive tree_rep: tree -> code -> label -> input -> LoopBool -> Prop :=
     (RESET: get_pc code pc = Some (ResetRegs gidl))
     (TR: tree_rep t code (S pc) inp b),
     tree_rep (GroupAction (Reset gidl) t) code pc inp b
+| tr_anchor:
+  forall code pc inp b a t
+    (ANCHOR: get_pc code pc = Some (CheckAnchor a))
+    (CHECK: anchor_satisfied rer a inp = true)
+    (TR: tree_rep t code (S pc) inp b),
+    tree_rep (AnchorPass a t) code pc inp b
+| tr_anchorfail:
+  forall code pc inp b a
+    (ANCHOR: get_pc code pc = Some (CheckAnchor a))
+    (CHECK: anchor_satisfied rer a inp = false),
+    tree_rep Mismatch code pc inp b
 | tr_readfail:
   forall code pc inp b cd
     (CONSUME: get_pc code pc = Some (Consume cd))
@@ -118,6 +129,12 @@ Proof.
   - inversion H0; subst; auto; same_instr.
     specialize (IHtree_rep _ TR) as EQT.
     subst. split; auto.
+  - inversion H0; subst; auto; same_instr;
+      rewrite CHECK0 in CHECK; inversion CHECK; subst.
+    specialize (IHtree_rep _ TR) as EQT.
+    subst. split; auto.
+  - inversion H0; subst; auto; same_instr.
+    rewrite CHECK0 in CHECK. discriminate.
   - inversion H0; subst; auto; same_instr.
     rewrite READ0 in READ. inversion READ.
   - inversion H0; subst; auto; same_instr.
@@ -239,9 +256,20 @@ Proof.
     eapply IHTREE; eauto. pike_subset.
     repeat (econstructor; eauto).
   (* anchor *)
-  - pike_subset.
+  - remember (Areg (Anchor a) :: cont) as anchorcont.
+    induction ACT; inversion Heqanchorcont; subst;
+      try solve[eapply tr_jmp; eauto]; clear IHACT.
+    invert_rep. inversion NFA; subst.
+    2: { in_subset. }
+    eapply tr_anchor; eauto.
+    eapply IHTREE; eauto. pike_subset.
   (* anchor fail *)
-  - pike_subset.
+  - remember (Areg (Anchor a) :: cont) as charcont.
+    induction ACT; inversion Heqcharcont; subst;
+      try solve[eapply tr_jmp; eauto]; clear IHACT.
+    invert_rep. inversion NFA; subst.
+    2: { in_subset. }
+    eapply tr_anchorfail; eauto.
 Qed.
 
 


### PR DESCRIPTION
To my knowledge, this covers every part of the `Engine/` to support anchors. I tried to also run the PikeVM with some example regex with anchors and an input; everything seems to be working.

None of the proofs required any new ideas. It was mostly a mechanical change.