### PR TITLE
Engine: MemoBT reuse memoization set

### DIFF
--- a/Engine/Correctness.v
+++ b/Engine/Correctness.v
@@ -231,7 +231,7 @@ Section MemoBTCorrectness.
 Definition trc_memo_tree := @trc mtree_state memotree_step.
 Definition trc_memo_bt (c:code) := @trc mbt_state (memobt_step rer c).
 
-(* The Pike invariant is preserved through the TRC *)
+(* The invariant is preserved through the TRC *)
 Lemma memobt_to_tree:
   forall mbs1 mts1 mbs2 code
     (STWF: stutter_wf rer code)
@@ -252,19 +252,32 @@ Qed.
 
 (* Any execution of MemoBT to a final state corresponds to an execution of MemoTree *)
 Theorem memobt_to_memotree:
-  forall r inp tree result ms,
+  forall r inp tree result initms finalms initts,
     pike_regex r ->
     bool_tree rer [Areg r] inp CanExit tree ->
-    trc_memo_bt (compilation r) (MemoBT.initial_state inp initial_memoset) (MBT_final result ms) ->
-    exists ts, trc_memo_tree (initial_tree_state tree inp initial_seentrees) (MTree_final result ts).
+    seen_inclusion rer (compilation r) initts initms None None ->
+    trc_memo_bt (compilation r) (MemoBT.initial_state inp initms) (MBT_final result finalms) ->
+    exists finalts, trc_memo_tree (initial_tree_state tree inp initts) (MTree_final result finalts).
 Proof.
-  intros r inp tree result ms SUBSET TREE TRCBT.
-  generalize (initial_memo_inv rer r inp tree (compilation r) TREE (@eq_refl _ _) SUBSET).
+  intros r inp tree result initms finalms initts SUBSET TREE INCL TRCBT.
+  generalize (initial_memo_inv_inclusion rer r inp tree (compilation r) initts initms TREE (@eq_refl _ _) SUBSET INCL).
   intros INIT.
   eapply memobt_to_tree in TRCBT as [btfinal [TRCTREE INV]]; eauto.
   - inversion INV; subst. eauto.
   - eapply compilation_stutter_wf; eauto.
 Qed.
+
+Theorem memobt_to_memotree_init:
+  forall r inp tree result finalms,
+    pike_regex r ->
+    bool_tree rer [Areg r] inp CanExit tree ->
+    trc_memo_bt (compilation r) (MemoBT.initial_state inp initial_memoset) (MBT_final result finalms) ->
+    exists finalts, trc_memo_tree (initial_tree_state tree inp initial_seentrees) (MTree_final result finalts).
+Proof.
+  intros r inp tree result finalms H H0 H1. eapply memobt_to_memotree; eauto.
+  apply initial_inclusion.
+Qed.      
+
 
 (* Through the TRC of MemoTree, the result is the result of the tree *)
 Lemma memo_tree_trc_correct:
@@ -279,9 +292,51 @@ Proof.
 Qed.
 
 
-(** * Correctness Theorem of the PikeVM result  *)
+(** * Correctness Theorem of the MemoBT result  *)
+
+(* A correct memoset to start MemoBT with is a MemoSet in which every element does not lead to a Match *)
+(* Concretely, this is a memoset that has an inclusion with a treeseen set (from MemoTree)
+   such that this treeseen set has no matching leaf *)
+Definition correctms (ms:memoset) (c:code) : Prop:=
+  exists ts,
+    seen_inclusion rer c ts ms None None /\
+      noleaf ts.
+
+Theorem correctms_init:
+  forall r, correctms initial_memoset (compilation r).
+Proof.
+  intros r. exists initial_seentrees. split.
+  - apply initial_inclusion.
+  - apply noleaf_initial.
+Qed.
 
 Theorem memobt_correct:
+  forall r inp tree result initms finalms,
+    (* the regex `r` is in the supported subset *)
+    pike_regex r ->
+    (* the initial memoset is correct  *)
+    correctms initms (compilation r) ->
+    (* `tree` is the tree of the regex `r` for the input `inp` *)
+    is_tree rer [Areg r] inp GroupMap.empty forward tree ->
+    (* the result of MemoBT is `result` *)
+    trc_memo_bt (compilation r) (MemoBT.initial_state inp initms) (MBT_final result finalms) ->
+    (* This `result` is the priority result of the `tree` *)
+    result = first_leaf tree inp.
+Proof.
+  intros r inp tree result initms finalms SUBSET CORRECT TREE TRC.
+  destruct CORRECT as [initts [INCL NOLEAF]].
+  eapply encode_equal with (b:=CanExit) in TREE as BOOLTREE; pike_subset.
+  eapply memobt_to_memotree in TRC as [ts TRC]; eauto.
+  assert (SUBTREE: pike_subtree tree).
+  { eapply pike_actions_pike_tree with (cont:=[Areg r]); eauto.
+    pike_subset. }
+  generalize (init_memotree_inv_noleaf tree inp initts SUBTREE NOLEAF). intros INIT.
+  eapply memo_tree_trc_correct in TRC as FINALINV; eauto.
+  inversion FINALINV. subst. auto. 
+Qed.
+
+
+Theorem memobt_correct_init:
   forall r inp tree result ms,
     (* the regex `r` is in the supported subset *)
     pike_regex r ->
@@ -293,19 +348,33 @@ Theorem memobt_correct:
     result = first_leaf tree inp.
 Proof.
   intros r inp tree result ms SUBSET TREE TRC.
-  eapply encode_equal with (b:=CanExit) in TREE as BOOLTREE; pike_subset.
-  eapply memobt_to_memotree in TRC as [ts TRC]; eauto.
-  assert (SUBTREE: pike_subtree tree).
-  { eapply pike_actions_pike_tree with (cont:=[Areg r]); eauto.
-    pike_subset. }
-  generalize (init_memotree_inv tree inp SUBTREE). intros INIT.
-  eapply memo_tree_trc_correct in TRC as FINALINV; eauto.
-  inversion FINALINV. subst. auto.
+  eapply memobt_correct; eauto. apply correctms_init.
 Qed.
 
-
-(* Equivalence of PikeVM to Warblre backtracking algorithm *)
+(* Equivalence of MemoBT to Warblre backtracking algorithm *)
 Theorem memobt_same_warblre:
+  forall lr wr inp initms finalms,
+    pike_regex lr ->
+    correctms initms (compilation lr) ->
+    equiv_regex wr lr ->
+    RegExpRecord.capturingGroupsCount rer = StaticSemantics.countLeftCapturingParensWithin wr nil ->
+    EarlyErrors.Pass_Regex wr nil ->
+    forall result,
+      trc_memo_bt (compilation lr) (MemoBT.initial_state inp initms) (MBT_final result finalms) ->
+      EquivDef.equiv_res result ((EquivMain.compilePattern wr rer) (input_str inp) (idx inp)).
+Proof.
+  intros lr wr inp initms finalms Hpike Hcorrect Hequiv Hcapcount HearlyErrors.
+  pose proof equiv_main wr lr rer inp Hequiv Hcapcount HearlyErrors as HequivMain.
+  destruct HequivMain as [m [res [Hcompsucc [Hexecsucc Hsameresult]]]].
+  unfold compilePattern. rewrite Hcompsucc, Hexecsucc.
+  set (tree := FunctionalUtils.compute_tr rer [Areg lr] inp GroupMap.empty forward).
+  specialize (Hsameresult tree eq_refl). destruct Hsameresult as [His_tree Hsameresult].
+  intros result Hpikeresult.
+  pose proof memobt_correct lr inp tree result initms finalms Hpike Hcorrect His_tree Hpikeresult as Hsameresult'.
+  rewrite Hsameresult'. assumption.
+Qed.
+
+Theorem memobt_same_warblre_init:
   forall lr wr inp ms,
     pike_regex lr ->
     equiv_regex wr lr ->
@@ -315,15 +384,10 @@ Theorem memobt_same_warblre:
       trc_memo_bt (compilation lr) (MemoBT.initial_state inp initial_memoset) (MBT_final result ms) ->
       EquivDef.equiv_res result ((EquivMain.compilePattern wr rer) (input_str inp) (idx inp)).
 Proof.
-  intros lr wr inp ms Hpike Hequiv Hcapcount HearlyErrors.
-  pose proof equiv_main wr lr rer inp Hequiv Hcapcount HearlyErrors as HequivMain.
-  destruct HequivMain as [m [res [Hcompsucc [Hexecsucc Hsameresult]]]].
-  unfold compilePattern. rewrite Hcompsucc, Hexecsucc.
-  set (tree := FunctionalUtils.compute_tr rer [Areg lr] inp GroupMap.empty forward).
-  specialize (Hsameresult tree eq_refl). destruct Hsameresult as [His_tree Hsameresult].
-  intros result Hpikeresult.
-  pose proof memobt_correct lr inp tree result ms Hpike His_tree Hpikeresult as Hsameresult'.
-  rewrite Hsameresult'. assumption.
+  intros lr wr inp ms H H0 H1 H2 result H3.
+  eapply memobt_same_warblre; eauto. apply correctms_init.
 Qed.
+
+
 
 End MemoBTCorrectness.

--- a/Engine/Correctness.v
+++ b/Engine/Correctness.v
@@ -257,13 +257,14 @@ Theorem memobt_to_memotree:
     bool_tree rer [Areg r] inp CanExit tree ->
     seen_inclusion rer (compilation r) initts initms None None ->
     trc_memo_bt (compilation r) (MemoBT.initial_state inp initms) (MBT_final result finalms) ->
-    exists finalts, trc_memo_tree (initial_tree_state tree inp initts) (MTree_final result finalts).
+    exists finalts, trc_memo_tree (initial_tree_state tree inp initts) (MTree_final result finalts) /\
+                 (result = None -> seen_inclusion rer (compilation r) finalts finalms None None).
 Proof.
   intros r inp tree result initms finalms initts SUBSET TREE INCL TRCBT.
   generalize (initial_memo_inv_inclusion rer r inp tree (compilation r) initts initms TREE (@eq_refl _ _) SUBSET INCL).
   intros INIT.
   eapply memobt_to_tree in TRCBT as [btfinal [TRCTREE INV]]; eauto.
-  - inversion INV; subst. eauto.
+  - inversion INV. subst. eauto. 
   - eapply compilation_stutter_wf; eauto.
 Qed.
 
@@ -272,11 +273,12 @@ Theorem memobt_to_memotree_init:
     pike_regex r ->
     bool_tree rer [Areg r] inp CanExit tree ->
     trc_memo_bt (compilation r) (MemoBT.initial_state inp initial_memoset) (MBT_final result finalms) ->
-    exists finalts, trc_memo_tree (initial_tree_state tree inp initial_seentrees) (MTree_final result finalts).
+    exists finalts, trc_memo_tree (initial_tree_state tree inp initial_seentrees) (MTree_final result finalts) /\
+                 (result = None -> seen_inclusion rer (compilation r) finalts finalms None None).
 Proof.
   intros r inp tree result finalms H H0 H1. eapply memobt_to_memotree; eauto.
   apply initial_inclusion.
-Qed.      
+Qed.
 
 
 (* Through the TRC of MemoTree, the result is the result of the tree *)
@@ -321,18 +323,21 @@ Theorem memobt_correct:
     (* the result of MemoBT is `result` *)
     trc_memo_bt (compilation r) (MemoBT.initial_state inp initms) (MBT_final result finalms) ->
     (* This `result` is the priority result of the `tree` *)
-    result = first_leaf tree inp.
+    result = first_leaf tree inp
+    (* when the result is None, the final memoset is correct *)
+    /\ (result = None -> correctms finalms (compilation r)).
 Proof.
   intros r inp tree result initms finalms SUBSET CORRECT TREE TRC.
-  destruct CORRECT as [initts [INCL NOLEAF]].
-  eapply encode_equal with (b:=CanExit) in TREE as BOOLTREE; pike_subset.
-  eapply memobt_to_memotree in TRC as [ts TRC]; eauto.
+  destruct CORRECT as [initts [INCL NOLEAF]]. 
+  eapply encode_equal with (b:=CanExit) in TREE as BOOLTREE; try solve[pike_subset].
+  eapply memobt_to_memotree in TRC as [ts [TRC CORRECT]]; eauto.
   assert (SUBTREE: pike_subtree tree).
   { eapply pike_actions_pike_tree with (cont:=[Areg r]); eauto.
     pike_subset. }
-  generalize (init_memotree_inv_noleaf tree inp initts SUBTREE NOLEAF). intros INIT.
+  pose proof (init_memotree_inv_noleaf tree inp initts SUBTREE NOLEAF) as INIT.
   eapply memo_tree_trc_correct in TRC as FINALINV; eauto.
-  inversion FINALINV. subst. auto. 
+  inversion FINALINV. subst. split; auto.
+  intros NL. apply CORRECT in NL as H1. apply NOLEAF0 in NL as H2. exists ts. split; auto.
 Qed.
 
 
@@ -345,11 +350,14 @@ Theorem memobt_correct_init:
     (* the result of MemoBT is `result` *)
     trc_memo_bt (compilation r) (MemoBT.initial_state inp initial_memoset) (MBT_final result ms) ->
     (* This `result` is the priority result of the `tree` *)
-    result = first_leaf tree inp.
+    result = first_leaf tree inp
+    (* when the result is None, the final memoset is correct *)
+    /\ (result = None -> correctms ms (compilation r)).
 Proof.
   intros r inp tree result ms SUBSET TREE TRC.
   eapply memobt_correct; eauto. apply correctms_init.
 Qed.
+
 
 (* Equivalence of MemoBT to Warblre backtracking algorithm *)
 Theorem memobt_same_warblre:
@@ -370,7 +378,7 @@ Proof.
   set (tree := FunctionalUtils.compute_tr rer [Areg lr] inp GroupMap.empty forward).
   specialize (Hsameresult tree eq_refl). destruct Hsameresult as [His_tree Hsameresult].
   intros result Hpikeresult.
-  pose proof memobt_correct lr inp tree result initms finalms Hpike Hcorrect His_tree Hpikeresult as Hsameresult'.
+  pose proof memobt_correct lr inp tree result initms finalms Hpike Hcorrect His_tree Hpikeresult as [Hsameresult' Hcorrect'].
   rewrite Hsameresult'. assumption.
 Qed.
 
@@ -387,7 +395,5 @@ Proof.
   intros lr wr inp ms H H0 H1 H2 result H3.
   eapply memobt_same_warblre; eauto. apply correctms_init.
 Qed.
-
-
 
 End MemoBTCorrectness.

--- a/Engine/FunctionalMemoBT.v
+++ b/Engine/FunctionalMemoBT.v
@@ -69,11 +69,11 @@ Definition memobt_fuel (r:regex) (inp:input) : nat :=
 
 Inductive matchres : Type :=
 | OutOfFuel
-| Finished: option leaf -> matchres.
+| Finished: option leaf -> memoset -> matchres.
 
 Definition getres (mbt:mbt_state) : matchres :=
   match mbt with
-  | MBT_final best _ => Finished best
+  | MBT_final best ms => Finished best ms
   | _ => OutOfFuel
   end.
 
@@ -150,13 +150,13 @@ Qed.
 
 (* when the function finishes, it returns the correct result *)
 Theorem memobt_match_correct:
-  forall r inp result,
-    memobt_match r inp = Finished result ->
-    exists ms, trc_memo_bt rer (compilation r) (initial_state inp initial_memoset) (MBT_final result ms).
+  forall r inp result ms,
+    memobt_match r inp = Finished result ms ->
+    trc_memo_bt rer (compilation r) (initial_state inp initial_memoset) (MBT_final result ms).
 Proof.
-  unfold memobt_match, getres. intros r inp result H.
+  unfold memobt_match, getres. intros r inp result ms H.
   match_destr; inversion H; subst.
-  eexists. eapply loop_trc; eauto.
+  eapply loop_trc; eauto.
 Qed.
 
 
@@ -164,11 +164,11 @@ Qed.
 Theorem memobt_match_terminates:
   forall r inp,
     pike_regex r ->
-    exists result, memobt_match r inp = Finished result.
+    exists result ms, memobt_match r inp = Finished result ms.
 Proof.
   intros r inp SUBSET. unfold memobt_match, memobt_fuel.
   apply memobt_complexity with (r:=r) (inp:=inp) in SUBSET as [result [ms TERM]].
-  exists result. apply steps_loop in TERM. rewrite TERM. auto.
+  exists result. exists ms. apply steps_loop in TERM. rewrite TERM. auto.
 Qed.
 
 End FunctionMemoBT.

--- a/Engine/MemoBT.v
+++ b/Engine/MemoBT.v
@@ -32,7 +32,7 @@ Section MemoBT.
   | MBT_final (res:option leaf) (ms:memoset): mbt_state.
 
   Definition initial_state (inp:input) (ms:memoset): mbt_state :=
-    MBT [(0, GroupMap.empty, CanExit, inp)] initial_memoset.
+    MBT [(0, GroupMap.empty, CanExit, inp)] ms.
 
   (** * MemoBT small-step semantics *)
 

--- a/Engine/MemoEquiv.v
+++ b/Engine/MemoEquiv.v
@@ -229,22 +229,23 @@ Section MemoEquiv.
   (** * Invariant Initialization  *)
 
   Lemma initial_inclusion:
-    forall c current currentpc,
-      seen_inclusion c initial_seentrees initial_memoset current currentpc.
+    forall c,
+      seen_inclusion c initial_seentrees initial_memoset None None.
   Proof.
-    intros c current currentpc. unfold seen_inclusion. intros pc b inp SEEN.
+    intros c. unfold seen_inclusion. intros pc b inp SEEN.
     rewrite initial_empty in SEEN. inversion SEEN.
   Qed.  
 
   (* the initial states of both smallstep semantics are related with the invariant *)
-  Lemma initial_memo_inv:
-    forall r inp tree code
+  Lemma initial_memo_inv_inclusion:
+    forall r inp tree code ts ms
       (TREE: bool_tree rer [Areg r] inp CanExit tree)
       (COMPILE: compilation r = code)
-      (SUBSET: pike_regex r),
-      memo_inv code (initial_tree_state tree inp initial_seentrees) (MemoBT.initial_state inp initial_memoset).
+      (SUBSET: pike_regex r)
+      (INCL: seen_inclusion code ts ms None None),
+      memo_inv code (initial_tree_state tree inp ts) (MemoBT.initial_state inp ms).
   Proof.
-    intros r inp tree code TREE COMPILE SUBSET.
+    intros r inp tree code ts ms TREE COMPILE SUBSET INCL.
     unfold compilation in COMPILE. destruct (compile r 0) as [c fresh] eqn:COMP.
     apply compile_nfa_rep with (prev := []) in COMP as REP; auto. simpl in REP.
     apply fresh_correct in COMP. simpl in COMP. subst.
@@ -257,9 +258,19 @@ Section MemoEquiv.
         * apply nfa_rep_extend; eauto.
         * replace (length c) with (length c + 0) by auto.
           rewrite get_prefix. auto.
-    - apply initial_inclusion.
+    - apply seen_inclusion_none. auto.
   Qed.
 
+  Lemma initial_memo_inv:
+    forall r inp tree code
+      (TREE: bool_tree rer [Areg r] inp CanExit tree)
+      (COMPILE: compilation r = code)
+      (SUBSET: pike_regex r),
+      memo_inv code (initial_tree_state tree inp initial_seentrees) (MemoBT.initial_state inp initial_memoset).
+  Proof.
+    intros r inp tree code TREE COMPILE SUBSET.
+    eapply initial_memo_inv_inclusion; eauto. apply initial_inclusion.
+  Qed.
 
   (** * Invariant Preservation  *)
 

--- a/Engine/MemoEquiv.v
+++ b/Engine/MemoEquiv.v
@@ -143,6 +143,16 @@ Section MemoEquiv.
            exists t gm, pc < cur /\ current = Some (t,gm,inp) /\
                      tree_config c (t,gm,inp) (pc,gm,b,inp)).
 
+  Lemma seen_inclusion_none:
+    forall c ts ms current currentpc
+      (INCL: seen_inclusion c ts ms None None),
+      seen_inclusion c ts ms current currentpc.
+  Proof.
+    unfold seen_inclusion. intros c ts ms current currentpc INCL pc b inp SEEN.
+    specialize (INCL pc b inp SEEN) as [[t [gm [IN EQ]]] | [ST [cur [H _]]]]; eauto.
+    inversion H.
+  Qed.
+  
   Lemma add_inclusion:
     forall treeseen memoset code inp tree pc gm b nextcurrent nextpc
       (INCL: seen_inclusion code treeseen memoset (Some (tree,gm,inp)) (Some pc))
@@ -159,8 +169,7 @@ Section MemoEquiv.
       + left. exists ts. exists gms. split; auto.
         apply in_add. left; auto. inversion EQ. auto.
   Qed.
-
-
+  
   Lemma skip_inclusion:
     forall code inp treeseen memoset tree gm currentpc
       (INCL: seen_inclusion code treeseen memoset (Some (tree, gm, inp)) currentpc)
@@ -212,7 +221,8 @@ Section MemoEquiv.
       (INCL: seen_inclusion code treeseen memoset (hd_error treestk) (head_pc stk)),
       memo_inv code (MTree treestk treeseen) (MBT stk memoset)
   | memoinv_final:
-    forall result ts ms,
+    forall result ts ms
+      (INCL: result = None -> seen_inclusion code ts ms None None),
       memo_inv code (MTree_final result ts) (MBT_final result ms).
 
 
@@ -224,8 +234,7 @@ Section MemoEquiv.
   Proof.
     intros c current currentpc. unfold seen_inclusion. intros pc b inp SEEN.
     rewrite initial_empty in SEEN. inversion SEEN.
-  Qed.
-
+  Qed.  
 
   (* the initial states of both smallstep semantics are related with the invariant *)
   Lemma initial_memo_inv:
@@ -782,6 +791,7 @@ Section MemoEquiv.
       assert (mbs2 = MBT_final (Some l) memoset); subst.
       { eapply memobt_deterministic; eauto. constructor; auto. }
       exists (MTree_final (Some l) treeseen). split; constructor; auto.
+      inversion 1.
     }
     (* We keep exploring *)
     specialize (exec_explore _ _ _ _ _ _ _ EXEC STUTTERS TC) as [expconfig [EXECBT LTCNEXT]].

--- a/Engine/MemoEquiv.v
+++ b/Engine/MemoEquiv.v
@@ -132,20 +132,20 @@ Section MemoEquiv.
   (* this happens during stuttering steps: such pcs are always stuttering, equivalent to the current active tree, *)
   (* but these pcs are not equal to the current pc : they're smaller *)
   (* the relation is then indexed by the current pc *)
-  Definition seen_inclusion (c:code) (treeseen:seentrees) (memoset:memoset) (current:option (tree*group_map*input)) (currentpc:label): Prop :=
+  Definition seen_inclusion (c:code) (treeseen:seentrees) (memoset:memoset) (current:option (tree*group_map*input)) (currentpc:option label): Prop :=
     forall pc b inp
       (SEEN: is_memo memoset pc b inp = true),
       (exists t gm,
           inseen treeseen t = true /\
             tree_config c (t, gm, inp) (pc, gm, b, inp))
       \/
-        (stutters pc c = true /\
-           exists t gm, pc < currentpc /\ current = Some (t,gm,inp) /\
+        (stutters pc c = true /\ exists cur, currentpc = Some cur /\
+           exists t gm, pc < cur /\ current = Some (t,gm,inp) /\
                      tree_config c (t,gm,inp) (pc,gm,b,inp)).
 
   Lemma add_inclusion:
     forall treeseen memoset code inp tree pc gm b nextcurrent nextpc
-      (INCL: seen_inclusion code treeseen memoset (Some (tree,gm,inp)) pc)
+      (INCL: seen_inclusion code treeseen memoset (Some (tree,gm,inp)) (Some pc))
       (TT: tree_config code (tree,gm,inp) (pc,gm,b,inp)),
       seen_inclusion code (add_seentrees treeseen tree) (memoize memoset pc b inp) nextcurrent nextpc.
   Proof.
@@ -153,8 +153,8 @@ Section MemoEquiv.
     unfold seen_inclusion in *.
     intros pc0 b0 inp0 SEEN. apply is_memo_add in SEEN. destruct SEEN as [EQ|SEEN].
     - inversion EQ. subst. left. exists tree. exists gm. split; auto. apply in_add. left. auto.
-    - specialize (INCL pc0 b0 inp0 SEEN).
-      destruct INCL as [[ts [gms [SEENs TTs]]] | [ST [ts [gms [GEQ [EQ TTS]]]]]].
+    - specialize (INCL pc0 b0 inp0 SEEN).      
+      destruct INCL as [[ts [gms [SEENs TTs]]] | [ST [cur [Hcur [ts [gms [GEQ [EQ TTS]]]]]]]].
       + left. exists ts. exists gms. split; auto. apply in_add. right; auto.
       + left. exists ts. exists gms. split; auto.
         apply in_add. left; auto. inversion EQ. auto.
@@ -172,7 +172,7 @@ Section MemoEquiv.
     unfold seen_inclusion in *.
     intros pc b inp0 SEENPC.
     specialize (INCL pc b inp0 SEENPC).
-    destruct INCL as [[ts [gms [SEENs TTs]]] | [ST [ts [gms [GEQ [EQ TTS]]]]]].
+    destruct INCL as [[ts [gms [SEENs TTs]]] | [ST [cur [Hcur [ts [gms [GEQ [EQ TTS]]]]]]]].
     - left. exists ts. exists gms. split; auto.
     - left. exists ts. exists gms. split; auto. inversion EQ. subst. auto.
   Qed.
@@ -180,28 +180,28 @@ Section MemoEquiv.
   Lemma stutter_inclusion:
     forall code inp treeseen memoset t gm pc b nextpc
       (GT: pc < nextpc )
-      (INCL: seen_inclusion code treeseen memoset (Some (t, gm, inp)) pc)
+      (INCL: seen_inclusion code treeseen memoset (Some (t, gm, inp)) (Some pc))
       (STUTTERS: stutters pc code = true)
       (TT: tree_config code (t,gm,inp) (pc,gm,b,inp)),
-      seen_inclusion code treeseen (memoize memoset pc b inp) (Some (t,gm,inp)) nextpc.
+      seen_inclusion code treeseen (memoize memoset pc b inp) (Some (t,gm,inp)) (Some nextpc).
   Proof.
     intros code inp treeseen memoset t gm pc b nextpc GT INCL STUTTERS TT.
     unfold seen_inclusion in *.
     intros pc0 b0 inp0 SEEN.
     apply is_memo_add in SEEN. destruct SEEN as [EQ | SEEN].
     { inversion EQ. subst. right. split; auto.
-      exists t. exists gm. split; auto. }
+      exists nextpc. split; auto. exists t. exists gm. split; auto. }
     specialize (INCL pc0 b0 inp0 SEEN).
-    destruct INCL as [[ts [gms [SEENs TTs]]] | [ST [ts [gms [GEQ [EQ TTS]]]]]].
+    destruct INCL as [[ts [gms [SEENs TTs]]] | [ST [cur [Hcur [ts [gms [GEQ [EQ TTS]]]]]]]].
     - left. exists ts. exists gms. split; auto.
-    - right. split; auto. exists ts. exists gms. split; auto. lia.
+    - right. split; auto. exists nextpc. split; auto. exists ts. exists gms. split; auto. inversion Hcur. lia.
   Qed.
 
-
-  Definition head_pc (stk:list config) : label :=
+  
+  Definition head_pc (stk:list config) : option label :=
     match stk with
-    | [] => 0
-    | (pc,_,_,_)::_ => pc
+    | [] => None
+    | (pc,_,_,_)::_ => Some pc
     end.
 
   (* Simulation Invariant *)
@@ -751,8 +751,8 @@ Section MemoEquiv.
       { inversion SKIP. }
       inversion MEMOSTEP; try (rewrite UNSEEN in SKIP; inversion SKIP); subst.
       inversion STACK; subst.
-      apply INCL in SKIP as [[teq [gmeq [SEENEQ TTEQ]]] | [STUTTER [t' [gm' [GEQ [EQ TTS]]]]]].
-      2: { lia. }
+      apply INCL in SKIP as [[teq [gmeq [SEENEQ TTEQ]]] | [STUTTER [cur [Hcur [t' [gm' [GEQ [EQ TTS]]]]]]]].
+      2: { inversion Hcur. lia. }
       assert (teq = tree); subst.
       { eapply tc_same_tree; eauto. }
       exists (MTree treelist treeseen). split; constructor; auto.

--- a/Engine/MemoTree.v
+++ b/Engine/MemoTree.v
@@ -27,7 +27,7 @@ Section MemoTree.
 
   Definition initial_tree_state (t:tree) (i:input) (ts:seentrees): mtree_state :=
     MTree [(t, GroupMap.empty, i)] ts.
-
+  
   (** * MemoTree small-step semantics *)
 
   Inductive exec_tree_result : Type :=
@@ -84,25 +84,6 @@ Section MemoTree.
     - eexists. eapply mtree_explore. eauto.
   Qed.
 
-  (** * MemoTree Correctness  *)
-  (* This algorithm always returns the leftmost accepting result of the initial tree *)
-
-  (* Invariant of the MemoTree execution *)
-  (* at any moment, all the possible results of the current state are all equal (equal to the first result of the original tree) *)
-  (* at any moment, all trees manipulated by the algorithms are trees for the subset of regexes supported  *)
-  Inductive memotree_inv: mtree_state -> option leaf -> Prop :=
-  | mi:
-    forall result stk seen
-      (SAMERES: forall res, list_nd stk seen res -> res = result)
-      (SUBSET: pike_list stk),
-      memotree_inv (MTree stk seen) result
-  | mi_final:
-    forall result ts,
-      memotree_inv (MTree_final result ts) result.
-
-  (* This uses the non-deterministic results of the stack, just like the PikeTree proof. *)
-  (* Such results can non-deteterministically skip any subtree in the seen set *)
-
   (** * Seentrees without results  *)
 
   Fixpoint noleaftree (t:tree) :=
@@ -143,6 +124,48 @@ Section MemoTree.
     - subst. auto.
     - apply H. auto.
   Qed.
+
+  (* We lift this definition to states, to have an execution invariant
+     when the initial tree has no result. *)
+  Definition noleaf_config (tc:tree_config) : Prop :=
+    noleaftree (fst (fst tc)) = true.
+
+  Inductive noleaf_stack : tree_stack -> Prop :=
+  | nls_nil: noleaf_stack []
+  | nls_cons: forall tc stk
+                (NLS: noleaf_stack stk)
+                (NLT: noleaf_config tc),
+      noleaf_stack (tc::stk).
+
+  Inductive noleaf_state : mtree_state -> Prop :=
+  | nlstate: forall tstk tseen
+               (NLSTK: noleaf_stack tstk)
+               (NLSEEN: noleaf tseen),
+      noleaf_state (MTree tstk tseen)
+  | nlstate_final: forall tseen
+                     (NLSEEN: noleaf tseen),
+      noleaf_state (MTree_final None tseen).
+
+
+  (** * MemoTree Correctness  *)
+  (* This algorithm always returns the leftmost accepting result of the initial tree *)
+
+  (* Invariant of the MemoTree execution *)
+  (* at any moment, all the possible results of the current state are all equal (equal to the first result of the original tree) *)
+  (* at any moment, all trees manipulated by the algorithms are trees for the subset of regexes supported  *)
+  Inductive memotree_inv: mtree_state -> option leaf -> Prop :=
+  | mi:
+    forall result stk seen
+      (SAMERES: forall res, list_nd stk seen res -> res = result)
+      (SUBSET: pike_list stk),
+      memotree_inv (MTree stk seen) result
+  | mi_final:
+    forall result ts,
+      memotree_inv (MTree_final result ts) result.
+
+  (* This uses the non-deterministic results of the stack, just like the PikeTree proof. *)
+  (* Such results can non-deteterministically skip any subtree in the seen set *)
+
   
   (** * Initialization  *)
   (* In the initial state, the invariant holds *)

--- a/Engine/MemoTree.v
+++ b/Engine/MemoTree.v
@@ -26,7 +26,7 @@ Section MemoTree.
   | MTree_final (res:option leaf) (ts:seentrees) : mtree_state.
 
   Definition initial_tree_state (t:tree) (i:input) (ts:seentrees): mtree_state :=
-    MTree [(t, GroupMap.empty, i)] initial_seentrees.
+    MTree [(t, GroupMap.empty, i)] ts.
 
   (** * MemoTree small-step semantics *)
 
@@ -103,6 +103,47 @@ Section MemoTree.
   (* This uses the non-deterministic results of the stack, just like the PikeTree proof. *)
   (* Such results can non-deteterministically skip any subtree in the seen set *)
 
+  (** * Seentrees without results  *)
+
+  Fixpoint noleaftree (t:tree) :=
+    match t with
+    | Mismatch | LKFail _ _ => true
+    | Match => false
+    | Choice t1 t2 => andb (noleaftree t1) (noleaftree t2)
+    | Read _ t1 | ReadBackRef _ t1 | Progress t1 | AnchorPass _ t1 | GroupAction _ t1 | LK _ _ t1 => noleaftree t1
+    end.
+  
+  (* tree without matching leaves *)
+  Lemma noleaf_tree:
+    forall t i gm d, noleaftree t = true -> tree_leaves t i gm d = [].
+  Proof.
+    intros t i gm d H. induction t; simpl; simpl in H; auto;
+      try solve[specialize (IHt H); eapply leaves_indep; eauto].
+    - inversion H.
+    - apply Bool.andb_true_iff in H as [H1 H2]. rewrite IHt1; try rewrite IHt2; auto.
+    - specialize (IHt2 H). destruct positivity; destruct (tree_leaves t1 i gm (lk_dir lk)) as [|[i' gm']]; auto.
+      eapply leaves_indep; eauto.
+  Qed.
+
+  (* set of trees without matching leaves *)
+  Definition noleaf (ts:seentrees) : Prop :=
+    forall t, inseen ts t = true -> noleaftree t = true.
+
+  Lemma noleaf_initial:
+    noleaf initial_seentrees.
+  Proof.
+    intros t IN. rewrite initial_nothing in IN. inversion IN.
+  Qed.
+
+  Lemma add_noleaf:
+    forall ts t, noleaf ts -> noleaftree t = true ->
+            noleaf (add_seentrees ts t).
+  Proof.
+    intros ts t H H0 t0 H1. apply in_add in H1 as [IS|IN].
+    - subst. auto.
+    - apply H. auto.
+  Qed.
+  
   (** * Initialization  *)
   (* In the initial state, the invariant holds *)
 
@@ -115,6 +156,46 @@ Section MemoTree.
     intros res LISTND.
     simpl. apply tree_nd_initial; auto.
     inversion LISTND; subst. inversion TLR; subst. rewrite seqop_none. auto.
+  Qed.
+
+  Lemma noleaftree_nd:
+    forall t gm inp,
+      pike_subtree t ->
+      noleaftree t = true ->
+      tree_nd t gm inp initial_seentrees None.
+  Proof.
+    intros t gm inp SUB H.
+    generalize dependent inp. generalize dependent gm.
+    induction t; intros; simpl in H; try solve[pike_subset].
+    - inversion H.
+    - assert (pike_subtree t1) by pike_subset.
+      assert (pike_subtree t2) by pike_subset.
+      apply Bool.andb_true_iff in H as [N1 N2].
+      rewrite <- seqop_none. apply tr_choice; auto.
+  Qed.
+
+  Lemma noleaf_nd:
+    forall t gm inp ts res,
+      pike_subtree t ->
+      noleaf ts ->
+      tree_nd t gm inp ts res ->
+      tree_nd t gm inp initial_seentrees res.
+  Proof.
+    intros t gm inp ts res SUB NL ND. induction ND; try solve[constructor; auto; pike_subset].
+    - apply NL in SEEN. apply noleaftree_nd; auto.
+  Qed.
+  
+  Lemma init_memotree_inv_noleaf:
+    forall t inp ts,
+      pike_subtree t ->
+      noleaf ts ->
+      memotree_inv (initial_tree_state t inp ts) (first_leaf t inp).
+  Proof.
+    intros t. unfold first_leaf. unfold initial_tree_state.
+    intros inp ts SUB NOLEAF; constructor; simpl; pike_subset; auto.
+    intros res LISTND.
+    inversion LISTND; subst. inversion TLR; subst. rewrite seqop_none.
+    apply noleaf_nd in TR; auto. apply tree_nd_initial; auto.
   Qed.
 
   (** * Invariant Preservation  *)

--- a/Engine/MemoTree.v
+++ b/Engine/MemoTree.v
@@ -186,6 +186,12 @@ Section MemoTree.
   (* This uses the non-deterministic results of the stack, just like the PikeTree proof. *)
   (* Such results can non-deteterministically skip any subtree in the seen set *)
 
+  (* The NOLEAF part of the invariant ensures that when the algorithm does not find a match,
+     then the treeseen set contains only trees without matches.
+     This allows the MemoBT algorithm to reuse its seen set when no result has been found,
+     and avoids exploring configurations that have been explored in a previous unfructuous run.
+   *)
+  
   
   (** * Initialization  *)
   (* In the initial state, the invariant holds *)
@@ -263,24 +269,33 @@ Section MemoTree.
       subst. constructor.
       intros H. apply NOLEAF in H as [_ H]. auto.
     (* skipping *)
-    - constructor; pike_subset.
-      + intros res LISTND.
-        apply SAMERES. eapply tlr_cons with (l1:=None); eauto.
-        apply tr_skip. auto.
-      + admit.
-      + admit.
+    - constructor; try solve[pike_subset].
+      2:{ intros N. apply NOLEAF in N as [N1 N2]. split; auto. inversion N1; auto. } 
+      intros res LISTND.
+      apply SAMERES. eapply tlr_cons with (l1:=None); eauto.
+      apply tr_skip. auto.
     (* match found *)
     - destruct t; inversion MATCH; subst.
       assert (Some (i,gm) = result).
       { apply SAMERES. eapply tlr_cons with (l2:=list_result stk0); try solve[constructor].
         apply list_result_nd. pike_subset. }
       subst. constructor.
+      intros N. inversion N.
     (* Mismatch *)
-    - simpl. constructor; pike_subset. intros res LISTND.
+    - simpl. constructor; try solve[pike_subset].
+      2:{ intros N. apply NOLEAF in N as [N1 N2]. inversion N1. split; auto.
+          apply add_noleaf; auto. } 
+      intros res LISTND.
       apply SAMERES. eapply tlr_cons; try solve[constructor].
-      eapply list_add_seen with (gm:=gm) (inp:=i) in LISTND; eauto.
+      eapply list_add_seen with (gm:=gm) (inp:=i) in LISTND; eauto. pike_subset. 
     (* Choice *)
-    - simpl. constructor; pike_subset. intros res LISTND.
+    - simpl. constructor; try solve[pike_subset].
+      2:{ intros N. apply NOLEAF in N as [N1 N2].
+          inversion N1. inversion NLT. apply Bool.andb_true_iff in H2 as [NL1 NL2].
+          split; auto.
+          - repeat (constructor; auto).
+          - apply add_noleaf; auto. }
+      intros res LISTND.
       inversion LISTND; subst. inversion TLR; subst.
       apply SAMERES.
       apply add_parent_tree in TR.
@@ -300,7 +315,10 @@ Section MemoTree.
         eapply list_add_seen_nd with (gm:=gm) in TLR0; eauto.
         econstructor; eauto.
     (* Read *)
-    - simpl. constructor; pike_subset. intros res LISTND.
+    - simpl. constructor; try solve[pike_subset].
+      2:{ intros N. apply NOLEAF in N as [N1 N2]. inversion N1.
+          split; auto. constructor; auto. apply add_noleaf; auto. }
+      intros res LISTND.
       inversion LISTND; subst. apply SAMERES.
       apply add_parent_tree in TR.
       2: { simpl. lia. }
@@ -309,12 +327,15 @@ Section MemoTree.
       (* case analysis: did t1 contribute to the result? *)
       destruct l1 as [leaf1|].
       + simpl. eapply tlr_cons; eauto.
-        apply list_result_nd; auto.
+        apply list_result_nd; auto. pike_subset.
       (* when the tree did not contribute, adding it to seen does not change the results *)
       + econstructor; eauto.
         eapply list_add_seen_nd with (gm:=gm) in TLR; eauto.
     (* Progress *)
-    - simpl. constructor; pike_subset. intros res LISTND.
+    - simpl. constructor; try solve[pike_subset].
+      2:{ intros N. apply NOLEAF in N as [N1 N2]. inversion N1.
+          split; auto. constructor; auto. apply add_noleaf; auto. }
+      intros res LISTND.
       inversion LISTND; subst. apply SAMERES.
       apply add_parent_tree in TR.
       2: { simpl. lia. }
@@ -323,12 +344,15 @@ Section MemoTree.
       (* case analysis: did t1 contribute to the result? *)
       destruct l1 as [leaf1|].
       + simpl. eapply tlr_cons; eauto.
-        apply list_result_nd; auto.
+        apply list_result_nd; auto. pike_subset.
       (* when the tree did not contribute, adding it to seen does not change the results *)
       + econstructor; eauto.
         eapply list_add_seen_nd with (gm:=gm) in TLR; eauto.
     (* AnchorPass *)
-    - simpl. constructor; pike_subset. intros res LISTND.
+    - simpl. constructor; try solve[pike_subset].
+      2:{ intros N. apply NOLEAF in N as [N1 N2]. inversion N1.
+          split; auto. constructor; auto. apply add_noleaf; auto. }
+      intros res LISTND.
       inversion LISTND; subst. apply SAMERES.
       apply add_parent_tree in TR.
       2: { simpl. lia. }
@@ -337,12 +361,15 @@ Section MemoTree.
       (* case analysis: did t1 contribute to the result? *)
       destruct l1 as [leaf1|].
       + simpl. eapply tlr_cons; eauto.
-        apply list_result_nd; auto.
+        apply list_result_nd; auto. pike_subset.
       (* when the tree did not contribute, adding it to seen does not change the results *)
       + econstructor; eauto.
         eapply list_add_seen_nd with (gm:=gm) in TLR; eauto.
     (* GroupAction *)
-    - simpl. constructor; pike_subset. intros res LISTND.
+    - simpl. constructor; try solve[pike_subset].
+      2:{ intros N. apply NOLEAF in N as [N1 N2]. inversion N1.
+          split; auto. constructor; auto. apply add_noleaf; auto. }
+      intros res LISTND.
       inversion LISTND; subst. apply SAMERES.
       apply add_parent_tree in TR.
       2: { simpl. lia. }
@@ -351,7 +378,7 @@ Section MemoTree.
       (* case analysis: did t1 contribute to the result? *)
       destruct l1 as [leaf1|].
       + simpl. eapply tlr_cons; eauto.
-        apply list_result_nd; auto.
+        apply list_result_nd; auto. pike_subset.
       (* when the tree did not contribute, adding it to seen does not change the results *)
       + econstructor; eauto.
         eapply list_add_seen_nd with (gm:=gm) in TLR; eauto.

--- a/Engine/MemoTree.v
+++ b/Engine/MemoTree.v
@@ -196,19 +196,6 @@ Section MemoTree.
   (** * Initialization  *)
   (* In the initial state, the invariant holds *)
 
-  Lemma init_memotree_inv:
-    forall t inp,
-      pike_subtree t -> 
-      memotree_inv (initial_tree_state t inp initial_seentrees) (first_leaf t inp).
-  Proof.
-    intros t. unfold first_leaf. unfold initial_tree_state. constructor; simpl; pike_subset; auto.
-    - intros res LISTND. 
-      simpl. apply tree_nd_initial; auto.
-      inversion LISTND; subst. inversion TLR; subst. rewrite seqop_none. auto.
-    - unfold noleaf_config. simpl. eapply noleaf_tree; eauto.
-    - apply noleaf_initial.
-  Qed.
-
   Lemma noleaftree_nd:
     forall t gm inp,
       pike_subtree t ->
@@ -250,6 +237,16 @@ Section MemoTree.
     - unfold noleaf_config. simpl. eapply noleaf_tree. eauto.
   Qed.
 
+  Lemma init_memotree_inv:
+    forall t inp,
+      pike_subtree t -> 
+      memotree_inv (initial_tree_state t inp initial_seentrees) (first_leaf t inp).
+  Proof.
+    intros. apply init_memotree_inv_noleaf; auto.
+    apply noleaf_initial.
+  Qed.
+
+  
   (** * Invariant Preservation  *)
 
   Theorem memotree_preservation:

--- a/Engine/MemoTree.v
+++ b/Engine/MemoTree.v
@@ -23,9 +23,9 @@ Section MemoTree.
   (* states of the MemoBT algorithm *)
   Inductive mtree_state : Type :=
   | MTree (stk:tree_stack) (ts: seentrees): mtree_state
-  | MTree_final (res:option leaf) : mtree_state.
+  | MTree_final (res:option leaf) (ts:seentrees) : mtree_state.
 
-  Definition initial_tree_state (t:tree) (i:input) : mtree_state :=
+  Definition initial_tree_state (t:tree) (i:input) (ts:seentrees): mtree_state :=
     MTree [(t, GroupMap.empty, i)] initial_seentrees.
 
   (** * MemoTree small-step semantics *)
@@ -54,7 +54,7 @@ Section MemoTree.
   Inductive memotree_step: mtree_state -> mtree_state -> Prop :=
   (* we exhausted all configurations, there is no match *)
   | mtree_nomatch: forall ts,
-      memotree_step (MTree [] ts) (MTree_final None)
+      memotree_step (MTree [] ts) (MTree_final None ts)
   (* the memoization allows to skip the current configuration *)
   | mtree_skip:
     forall ts t gm i stk
@@ -64,7 +64,7 @@ Section MemoTree.
   | mtree_match:
     forall ts t gm i leaf stk
       (MATCH: exec_tree (t,gm,i) = TMatch leaf),
-      memotree_step (MTree ((t,gm,i)::stk) ts) (MTree_final (Some leaf))
+      memotree_step (MTree ((t,gm,i)::stk) ts) (MTree_final (Some leaf) ts)
   (* we keep exploring, and add each handled tree to the treeseen set *)
   | mtree_explore:
     forall ts t gm i nextconfs stk
@@ -97,8 +97,8 @@ Section MemoTree.
       (SUBSET: pike_list stk),
       memotree_inv (MTree stk seen) result
   | mi_final:
-    forall result,
-      memotree_inv (MTree_final result) result.
+    forall result ts,
+      memotree_inv (MTree_final result ts) result.
 
   (* This uses the non-deterministic results of the stack, just like the PikeTree proof. *)
   (* Such results can non-deteterministically skip any subtree in the seen set *)
@@ -108,8 +108,8 @@ Section MemoTree.
 
   Lemma init_memotree_inv:
     forall t inp,
-      pike_subtree t ->
-      memotree_inv (initial_tree_state t inp) (first_leaf t inp).
+      pike_subtree t -> 
+      memotree_inv (initial_tree_state t inp initial_seentrees) (first_leaf t inp).
   Proof.
     intros t. unfold first_leaf. unfold initial_tree_state. constructor; simpl; pike_subset; auto.
     intros res LISTND.

--- a/Engine/MemoTree.v
+++ b/Engine/MemoTree.v
@@ -91,19 +91,46 @@ Section MemoTree.
     | Mismatch | LKFail _ _ => true
     | Match => false
     | Choice t1 t2 => andb (noleaftree t1) (noleaftree t2)
-    | Read _ t1 | ReadBackRef _ t1 | Progress t1 | AnchorPass _ t1 | GroupAction _ t1 | LK _ _ t1 => noleaftree t1
+    | Read _ t1 | ReadBackRef _ t1 | Progress t1 | AnchorPass _ t1 | GroupAction _ t1 => noleaftree t1
+    | LK lk tlk t1 =>
+        match positivity lk with
+        | true => orb (noleaftree tlk) (noleaftree t1)
+        | false => orb (negb (noleaftree tlk)) (noleaftree t1)
+        end
     end.
   
   (* tree without matching leaves *)
   Lemma noleaf_tree:
-    forall t i gm d, noleaftree t = true -> tree_leaves t i gm d = [].
+    forall t i gm d, noleaftree t = true <-> tree_res t gm i d = None.
   Proof.
-    intros t i gm d H. induction t; simpl; simpl in H; auto;
-      try solve[specialize (IHt H); eapply leaves_indep; eauto].
-    - inversion H.
-    - apply Bool.andb_true_iff in H as [H1 H2]. rewrite IHt1; try rewrite IHt2; auto.
-    - specialize (IHt2 H). destruct positivity; destruct (tree_leaves t1 i gm (lk_dir lk)) as [|[i' gm']]; auto.
-      eapply leaves_indep; eauto.
+    intros t i gm d. induction t; simpl; split; intros H; auto;
+      try solve[inversion H];
+      try solve[apply IHt in H; eapply res_indep; eauto];
+      try solve[eapply res_indep in H; eapply IHt in H; auto].
+    - apply Bool.andb_true_iff in H as [H1 H2].
+      apply IHt1 in H1. apply IHt2 in H2. rewrite H1, H2. auto.
+    - destruct (tree_res t1 gm i d) eqn:TR1; simpl in H; inversion H.
+      apply Bool.andb_true_iff. split.
+      + apply IHt1. auto.
+      + apply IHt2. auto.
+    - destruct positivity eqn:POS.
+      + destruct (tree_res t1 gm i (lk_dir lk)) as [[i' gm']|]eqn:TL1; auto.
+        apply Bool.orb_true_iff in H as [H1 | H2].
+        * apply IHt1 in H1. eapply res_indep in H1. rewrite TL1 in H1. inversion H1.
+        * eapply res_indep. apply IHt2. auto.
+      + destruct (tree_res t1 gm i (lk_dir lk)) as [[i' gm']|]eqn:TL1; auto.
+        apply Bool.orb_true_iff in H as [H1 | H2].
+        * destruct (noleaftree t1) eqn:HN1; try inversion H1.
+          eapply res_indep in TL1. eapply IHt1 in TL1. inversion TL1.
+        * apply IHt2. auto.
+    - destruct positivity eqn:POS; apply Bool.orb_true_iff.
+      + destruct (tree_res t1 gm i (lk_dir lk)) as [[i' gm']|]eqn:TL1; auto.
+        * right. apply IHt2. eapply res_indep. eauto.
+        * left. apply IHt1. eapply res_indep. eauto.
+      + destruct (tree_res t1 gm i (lk_dir lk)) as [[i' gm']|]eqn:TL1; auto.
+        * left. apply Bool.eq_true_not_negb. intros H1. apply IHt1 in H1.
+          eapply res_indep in H1. rewrite TL1 in H1. inversion H1.
+        * right. apply IHt2. auto.
   Qed.
 
   (* set of trees without matching leaves *)
@@ -125,7 +152,7 @@ Section MemoTree.
     - apply H. auto.
   Qed.
 
-  (* We lift this definition to states, to have an execution invariant
+  (* We lift this definition to stacks, to have an execution invariant
      when the initial tree has no result. *)
   Definition noleaf_config (tc:tree_config) : Prop :=
     noleaftree (fst (fst tc)) = true.
@@ -136,15 +163,6 @@ Section MemoTree.
                 (NLS: noleaf_stack stk)
                 (NLT: noleaf_config tc),
       noleaf_stack (tc::stk).
-
-  Inductive noleaf_state : mtree_state -> Prop :=
-  | nlstate: forall tstk tseen
-               (NLSTK: noleaf_stack tstk)
-               (NLSEEN: noleaf tseen),
-      noleaf_state (MTree tstk tseen)
-  | nlstate_final: forall tseen
-                     (NLSEEN: noleaf tseen),
-      noleaf_state (MTree_final None tseen).
 
 
   (** * MemoTree Correctness  *)
@@ -157,10 +175,12 @@ Section MemoTree.
   | mi:
     forall result stk seen
       (SAMERES: forall res, list_nd stk seen res -> res = result)
-      (SUBSET: pike_list stk),
+      (SUBSET: pike_list stk)
+      (NOLEAF: result = None -> noleaf_stack stk /\ noleaf seen),
       memotree_inv (MTree stk seen) result
   | mi_final:
-    forall result ts,
+    forall result ts
+      (NOLEAF: result = None -> noleaf ts),
       memotree_inv (MTree_final result ts) result.
 
   (* This uses the non-deterministic results of the stack, just like the PikeTree proof. *)
@@ -176,9 +196,11 @@ Section MemoTree.
       memotree_inv (initial_tree_state t inp initial_seentrees) (first_leaf t inp).
   Proof.
     intros t. unfold first_leaf. unfold initial_tree_state. constructor; simpl; pike_subset; auto.
-    intros res LISTND.
-    simpl. apply tree_nd_initial; auto.
-    inversion LISTND; subst. inversion TLR; subst. rewrite seqop_none. auto.
+    - intros res LISTND. 
+      simpl. apply tree_nd_initial; auto.
+      inversion LISTND; subst. inversion TLR; subst. rewrite seqop_none. auto.
+    - unfold noleaf_config. simpl. eapply noleaf_tree; eauto.
+    - apply noleaf_initial.
   Qed.
 
   Lemma noleaftree_nd:
@@ -216,9 +238,10 @@ Section MemoTree.
   Proof.
     intros t. unfold first_leaf. unfold initial_tree_state.
     intros inp ts SUB NOLEAF; constructor; simpl; pike_subset; auto.
-    intros res LISTND.
-    inversion LISTND; subst. inversion TLR; subst. rewrite seqop_none.
-    apply noleaf_nd in TR; auto. apply tree_nd_initial; auto.
+    - intros res LISTND.
+      inversion LISTND; subst. inversion TLR; subst. rewrite seqop_none.
+      apply noleaf_nd in TR; auto. apply tree_nd_initial; auto.
+    - unfold noleaf_config. simpl. eapply noleaf_tree. eauto.
   Qed.
 
   (** * Invariant Preservation  *)
@@ -238,10 +261,14 @@ Section MemoTree.
     - assert (None = result).
       { apply SAMERES. constructor. }
       subst. constructor.
+      intros H. apply NOLEAF in H as [_ H]. auto.
     (* skipping *)
-    - constructor; pike_subset. intros res LISTND.
-      apply SAMERES. eapply tlr_cons with (l1:=None); eauto.
-      apply tr_skip. auto.
+    - constructor; pike_subset.
+      + intros res LISTND.
+        apply SAMERES. eapply tlr_cons with (l1:=None); eauto.
+        apply tr_skip. auto.
+      + admit.
+      + admit.
     (* match found *)
     - destruct t; inversion MATCH; subst.
       assert (Some (i,gm) = result).

--- a/Engine/NFA.v
+++ b/Engine/NFA.v
@@ -14,6 +14,8 @@ Section NFA.
   (* the bytecode generated for the PikeVM algorithm *)
 
   Definition label : Type := nat.
+  Definition lbl_eq_dec : forall (l1 l2 : label), { l1 = l2 } + { l1 <> l2 }.
+  Proof. repeat decide equality. Defined.
 
   Inductive bytecode: Type :=
   | Accept

--- a/Engine/PikeTree.v
+++ b/Engine/PikeTree.v
@@ -367,7 +367,7 @@ Section PikeTree.
   Proof.
     intros inp active best blocked future seen res erased ERASE ND.
     inversion ERASE; subst; auto.
-    eapply state_nd_future_none; eauto using res_group_map_indep.
+    eapply state_nd_future_none; eauto using res_indep.
   Qed.
 
 
@@ -425,7 +425,7 @@ Section PikeTree.
         inversion TREE. inversion CONT. destruct plus; [discriminate|subst].
         replace titer with t0 by eauto using bool_tree_determ.
         replace tskip with t by eauto using bool_tree_determ.
-        unfold first_leaf in *. simpl. apply res_group_map_indep with (inp2:=inp) (gm2:=GroupMap.empty) (dir2:=forward) in NORES as ->. now destruct (tree_res t).
+        unfold first_leaf in *. simpl. apply res_indep with (inp2:=inp) (gm2:=GroupMap.empty) (dir2:=forward) in NORES as ->. now destruct (tree_res t).
       } rewrite Heq.
       now eapply init_piketree_inv.
     }
@@ -442,7 +442,7 @@ Section PikeTree.
     intros. rewrite first_tree_leaf. rewrite first_tree_leaf in NORES.
     destruct (tree_leaves t gm1 inp1 forward) eqn:HTL.
     2: { inversion NORES. }
-    eapply leaves_group_map_indep in HTL. rewrite HTL. auto.
+    eapply leaves_indep in HTL. rewrite HTL. auto.
   Qed.
 
   (* the same is true for a non-deterministic result *)
@@ -671,7 +671,7 @@ Section PikeTree.
         now rewrite <-seqop_assoc.
       (* we erased `future` *)
       + unfold first_leaf in NORES |- *.
-        eapply res_group_map_indep in NORES.
+        eapply res_indep in NORES.
         simpl. unfold advance_input', advance_input. rewrite NORES.
         now destruct (tree_res t1).
     (* nextchar_filter *)

--- a/Rewriting/Equivalence.v
+++ b/Rewriting/Equivalence.v
@@ -768,7 +768,7 @@ Section Congruence.
       + unfold lk_result in RES_LK. rewrite Hpos in RES_LK.
         destruct (tree_res treelk gm inp (lk_dir lk)) eqn:TREERES; inversion RES_LK. subst.
         assert (tree_leaves treelk gmlk inp (lk_dir lk) = []).
-        { apply leaves_group_map_indep with (gm1 := gmlk) (inp1 := inp) (dir1 := lk_dir lk).
+        { apply leaves_indep with (gm1 := gmlk) (inp1 := inp) (dir1 := lk_dir lk).
           apply hd_error_none_nil. rewrite <- first_tree_leaf. auto. }
         simpl. rewrite Hpos, H. auto.
 

--- a/Semantics/Tree.v
+++ b/Semantics/Tree.v
@@ -264,23 +264,23 @@ Section Tree.
     - destruct (positivity lk) eqn:Hlkpos. + now apply first_tree_leaf_poslk. + now apply first_tree_leaf_neglk.
   Qed.
 
-  (** * Group Map irrelevance  *)
-  (* finding a match does not depend on the initial group map *)
+  (** * No Result - argument irrelevance  *)
+  (* finding no leaves in a tree does not depend on the initial group map, the initial input, and the initial direction *)
   (* we could phrase a stronger theorem about how to relate the two results *)
   (* but for now we only need to differentiate when there is no results from when there is one *)
 
-  (* Group map irrelevance property for a given tree. *)
-  Definition leaves_group_map_indep_prop (t: tree): Prop :=
+  (* irrelevance property for a given tree. *)
+  Definition leaves_indep_prop (t: tree): Prop :=
     forall gm1 gm2 inp1 inp2 dir1 dir2,
       tree_leaves t gm1 inp1 dir1 = [] -> tree_leaves t gm2 inp2 dir2 = [].
 
   (* Intermediate lemma for positive lookarounds *)
-  Lemma leaves_group_map_indep_poslk:
+  Lemma leaves_indep_poslk:
     forall lk tlk t1,
-      positivity lk = true -> leaves_group_map_indep_prop tlk -> leaves_group_map_indep_prop t1 ->
-      leaves_group_map_indep_prop (LK lk tlk t1).
+      positivity lk = true -> leaves_indep_prop tlk -> leaves_indep_prop t1 ->
+      leaves_indep_prop (LK lk tlk t1).
   Proof.
-    intros lk tlk t1 Hposlk IHtlk IHt1; unfold leaves_group_map_indep_prop in *; simpl.
+    intros lk tlk t1 Hposlk IHtlk IHt1; unfold leaves_indep_prop in *; simpl.
     rewrite Hposlk. intros gm1 gm2 inp1 inp2 dir1 dir2 Hnil1.
     specialize (IHtlk gm1 gm2 inp1 inp2 (lk_dir lk) (lk_dir lk)). destruct (tree_leaves tlk gm1 inp1 _) as [|[inp' gm'] q]; simpl in *.
     1: { specialize (IHtlk eq_refl). now rewrite IHtlk. }
@@ -289,12 +289,12 @@ Section Tree.
   Qed.
 
   (* Intermediate lemma for negative lookarounds *)
-  Lemma leaves_group_map_indep_neglk:
+  Lemma leaves_indep_neglk:
     forall lk tlk t1,
-      positivity lk = false -> leaves_group_map_indep_prop tlk -> leaves_group_map_indep_prop t1 ->
-      leaves_group_map_indep_prop (LK lk tlk t1).
+      positivity lk = false -> leaves_indep_prop tlk -> leaves_indep_prop t1 ->
+      leaves_indep_prop (LK lk tlk t1).
   Proof.
-    intros lk tlk t1 Hposlk IHtlk IHt1; unfold leaves_group_map_indep_prop in *; simpl.
+    intros lk tlk t1 Hposlk IHtlk IHt1; unfold leaves_indep_prop in *; simpl.
     rewrite Hposlk. intros gm1 gm2 inp1 inp2 dir1 dir2 Hnil1.
     destruct (tree_leaves tlk gm1 inp1 _) as [|[inp' gm'] q] eqn:Hnilsub1; simpl in *.
     1: { specialize (IHtlk gm1 gm2 inp1 inp2 (lk_dir lk) (lk_dir lk) Hnilsub1). rewrite IHtlk. eapply IHt1; eauto. }
@@ -303,7 +303,7 @@ Section Tree.
   Qed.
 
 
-  Lemma leaves_group_map_indep:
+  Lemma leaves_indep:
     forall t gm1 gm2 inp1 inp2 dir1 dir2,
       tree_leaves t gm1 inp1 dir1 = [] -> tree_leaves t gm2 inp2 dir2 = [].
   Proof.
@@ -314,12 +314,12 @@ Section Tree.
       apply IHt1 with (gm2:=gm2) (inp2:=inp2) (dir2:=dir2) in NIL1. apply IHt2 with (gm2:=gm2) (inp2:=inp2) (dir2:=dir2) in NIL2.
       rewrite NIL1. rewrite NIL2. auto.
     - destruct (positivity lk) eqn:Hlkpos.
-      + eapply leaves_group_map_indep_poslk; eauto.
-      + eapply leaves_group_map_indep_neglk; eauto.
+      + eapply leaves_indep_poslk; eauto.
+      + eapply leaves_indep_neglk; eauto.
   Qed.
 
 
-  (* Corollary: group map irrelevance in terms of tree_res *)
+  (* Corollary: argument irrelevance in terms of tree_res *)
   (* A lemma about hd_error *)
   Lemma hd_error_none_nil {A}:
     forall l: list A, hd_error l = None <-> l = [].
@@ -329,11 +329,11 @@ Section Tree.
     - subst l. reflexivity.
   Qed.
 
-  Lemma res_group_map_indep:
+  Lemma res_indep:
     forall t gm1 gm2 inp1 inp2 dir1 dir2,
       tree_res t gm1 inp1 dir1 = None -> tree_res t gm2 inp2 dir2 = None.
   Proof.
-    intros. rewrite first_tree_leaf, hd_error_none_nil in *. eauto using leaves_group_map_indep.
+    intros. rewrite first_tree_leaf, hd_error_none_nil in *. eauto using leaves_indep.
   Qed.
 
   Lemma leaf_eq_dec (l1 l2: leaf): {l1 = l2} + {l1 <> l2}.


### PR DESCRIPTION
Proof that the memoization set of the MemoBT algorithm can be reused after an unfructuous search.

Main changes:
- The MemoBT algorithm returns not only the match result, but also its memoset
- Same for MemoTree, which returns a tree memoization set
- A notion of "correct" memoset is defined, for memoization set containing configurations that cannot lead to a match

Proof changes:
- This proves that starting MemoBT with any correct memoset (not just the empty set) returns the same result
- This also proves that starting MemoBT with a correct memoset and finding no result also returns a correct memoset (that can be used in subsequent searches)