### PR TITLE
Use Rocq released opam repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,7 @@ jobs:
       - name: Install opam dependencies
         run: |
           opam repo add rocq-released https://rocq-prover.org/opam/released
-          # keep the refs in sync with the README
-          opam pin add --no-action warblre.0.1.0 https://github.com/epfl-systemf/Warblre.git#a5a312072b892f4fb0343b8c2ac9d35d451c84f1
-          opam pin add --no-action strict-order-solver.0.1.0 https://github.com/epfl-systemf/StrictOrderSolver.git#c2c6b1ff316770e9f0ec37141b465971733633e3
-          opam install . --deps-only
+          opam install . --deps-only --yes
 
       - name: Dune build
         run: opam exec -- dune build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Install opam dependencies
         run: |
+          opam repo add rocq-released https://rocq-prover.org/opam/released
           # keep the refs in sync with the README
           opam pin add --no-action warblre.0.1.0 https://github.com/epfl-systemf/Warblre.git#a5a312072b892f4fb0343b8c2ac9d35d451c84f1
           opam pin add --no-action strict-order-solver.0.1.0 https://github.com/epfl-systemf/StrictOrderSolver.git#c2c6b1ff316770e9f0ec37141b465971733633e3

--- a/README.md
+++ b/README.md
@@ -36,17 +36,10 @@ This includes:
    opam repo add rocq-released https://rocq-prover.org/opam/released
    ```
 
-3. Pin the versions of dependencies:
-
-   ```
-   opam pin add --no-action warblre.0.1.0 https://github.com/epfl-systemf/Warblre.git#a5a312072b892f4fb0343b8c2ac9d35d451c84f1
-   opam pin add --no-action strict-order-solver.0.1.0 https://github.com/epfl-systemf/StrictOrderSolver.git#c2c6b1ff316770e9f0ec37141b465971733633e3
-   ```
-
-4. Install dependencies:
+3. Install dependencies:
 
    ```
    opam install --deps-only .
    ```
 
-5. Build all proofs with `dune build`.
+4. Build all proofs with `dune build`.

--- a/README.md
+++ b/README.md
@@ -30,17 +30,23 @@ This includes:
    opam switch --no-install create .
    ```
 
-2. Pin the versions of dependencies:
+2. Add needed dependency repositories:
+
+   ```
+   opam repo add rocq-released https://rocq-prover.org/opam/released
+   ```
+
+3. Pin the versions of dependencies:
 
    ```
    opam pin add --no-action warblre.0.1.0 https://github.com/epfl-systemf/Warblre.git#a5a312072b892f4fb0343b8c2ac9d35d451c84f1
    opam pin add --no-action strict-order-solver.0.1.0 https://github.com/epfl-systemf/StrictOrderSolver.git#c2c6b1ff316770e9f0ec37141b465971733633e3
    ```
 
-3. Install dependencies:
+4. Install dependencies:
 
    ```
    opam install --deps-only .
    ```
 
-4. Build all proofs with `dune build`.
+5. Build all proofs with `dune build`.

--- a/dune-project
+++ b/dune-project
@@ -17,6 +17,6 @@
  (synopsis "Formal Verification for JavaScript Regular Expressions")
  (depends
   (rocq-core (= 9.1.1))
-  (rocq-stdlib (= 9.0.0))
+  (rocq-stdlib (= 9.1.0))
   (warblre (= 0.1.0))
   (strict-order-solver (>= 1.0.0))))

--- a/dune-project
+++ b/dune-project
@@ -19,4 +19,4 @@
   (rocq-core (= 9.1.1))
   (rocq-stdlib (= 9.0.0))
   (warblre (= 0.1.0))
-  (strict-order-solver (= 0.1.0))))
+  (strict-order-solver (>= 1.0.0))))

--- a/dune-project
+++ b/dune-project
@@ -16,6 +16,7 @@
  (name linden)
  (synopsis "Formal Verification for JavaScript Regular Expressions")
  (depends
-  (rocq-prover (= 9.0.0))
+  (rocq-core (= 9.1.1))
+  (rocq-stdlib (= 9.0.0))
   (warblre (= 0.1.0))
   (strict-order-solver (= 0.1.0))))

--- a/linden.opam
+++ b/linden.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/epfl-systemf/Linden/issues"
 depends: [
   "dune" {>= "3.21"}
   "rocq-core" {= "9.1.1"}
-  "rocq-stdlib" {= "9.0.0"}
+  "rocq-stdlib" {= "9.1.0"}
   "warblre" {= "0.1.0"}
   "strict-order-solver" {>= "1.0.0"}
   "odoc" {with-doc}

--- a/linden.opam
+++ b/linden.opam
@@ -11,7 +11,7 @@ depends: [
   "rocq-core" {= "9.1.1"}
   "rocq-stdlib" {= "9.0.0"}
   "warblre" {= "0.1.0"}
-  "strict-order-solver" {= "0.1.0"}
+  "strict-order-solver" {>= "1.0.0"}
   "odoc" {with-doc}
 ]
 build: [
@@ -29,3 +29,6 @@ build: [
   ]
 ]
 x-maintenance-intent: ["(latest)"]
+pin-depends: [
+  ["warblre.0.1.0" "git+https://github.com/epfl-systemf/Warblre.git#a5a312072b892f4fb0343b8c2ac9d35d451c84f1" ]
+]

--- a/linden.opam
+++ b/linden.opam
@@ -8,7 +8,8 @@ homepage: "https://github.com/epfl-systemf/Linden"
 bug-reports: "https://github.com/epfl-systemf/Linden/issues"
 depends: [
   "dune" {>= "3.21"}
-  "rocq-prover" {= "9.0.0"}
+  "rocq-core" {= "9.1.1"}
+  "rocq-stdlib" {= "9.0.0"}
   "warblre" {= "0.1.0"}
   "strict-order-solver" {= "0.1.0"}
   "odoc" {with-doc}

--- a/linden.opam.template
+++ b/linden.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["warblre.0.1.0" "git+https://github.com/epfl-systemf/Warblre.git#a5a312072b892f4fb0343b8c2ac9d35d451c84f1" ]
+]


### PR DESCRIPTION
Apparently usage of the main opam repository is not the expected workflow https://github.com/ocaml/opam-repository/pull/29617#discussion_r3029341986

Also, the `rocq-prover` opam package is mismanaged IMO and should not be used.